### PR TITLE
Upgrades mw and api for traefik v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            docker.io/kubitodev/traefik-ip-whitelist-sync
+            docker.io/kubitodev/traefik-ip-allowlist-sync
           tags: |
             # Gets the new_tag output from the previous step
             type=semver,pattern={{version}},value=${{ steps.autotag.outputs.new_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN pip install kubernetes==23.3.0
 COPY sync.py .
 
 # Set the required variables by the script
-ENV WHITELIST_CUSTOM_DOMAIN=
-ENV WHITELIST_MIDDLEWARE_NAME=ip-whitelist
-ENV WHITELIST_TRAEFIK_NAMESPACE=traefik-system
+ENV ALLOWLIST_CUSTOM_DOMAIN=
+ENV ALLOWLIST_MIDDLEWARE_NAME=ip-allowlist
+ENV ALLOWLIST_TRAEFIK_NAMESPACE=traefik-system
 
 # Run the script
 CMD ["python", "sync.py"]

--- a/manifests/cronjob.yaml
+++ b/manifests/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: traefik-whitelist-sync
+  name: traefik-allowlist-sync
 spec:
   schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 1
@@ -11,13 +11,13 @@ spec:
         spec:
           serviceAccountName: traefik
           containers:
-            - name: traefik-whitelist-sync
-              image: kubitodev/traefik-ip-whitelist-sync:latest
+            - name: traefik-allowlist-sync
+              image: kubitodev/traefik-ip-allowlist-sync:latest
               env:
-                - name: WHITELIST_MIDDLEWARE_NAME
-                  value: ip-whitelist
-                - name: WHITELIST_TRAEFIK_NAMESPACE
+                - name: ALLOWLIST_MIDDLEWARE_NAME
+                  value: ip-allowlist
+                - name: ALLOWLIST_TRAEFIK_NAMESPACE
                   value: traefik-system
-                # - name: WHITELIST_CUSTOM_DOMAIN
+                # - name: ALLOWLIST_CUSTOM_DOMAIN
                 #   value: example.com
           restartPolicy: OnFailure

--- a/manifests/middleware.yaml
+++ b/manifests/middleware.yaml
@@ -1,9 +1,9 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: ip-whitelist
+  name: ip-allowlist
 spec:
-  ipWhiteList:
+  ipAllowList:
     sourceRange:
       - 1.1.1.1 # dynamically changing
     # Uncomment if you need to set depth

--- a/manifests/role.yaml
+++ b/manifests/role.yaml
@@ -3,6 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: patch-middleware
 rules:
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.io"]
   resources: ["middlewares"]
   verbs: ["patch"]

--- a/sync.py
+++ b/sync.py
@@ -10,7 +10,7 @@ def main():
     config.load_incluster_config()
     api = client.CustomObjectsApi()
 
-    custom_domain = os.environ.get('WHITELIST_CUSTOM_DOMAIN')
+    custom_domain = os.environ.get('ALLOWLIST_CUSTOM_DOMAIN')
 
     current = []
     public_ip = urlopen('https://api.ipify.org').read().decode('utf8')
@@ -23,17 +23,17 @@ def main():
 
     patch_body = {
         "spec": {
-            "ipWhiteList": {
+            "ipAllowList": {
                 "sourceRange": current
             }
         }
     }
 
-    name = os.environ.get('WHITELIST_MIDDLEWARE_NAME', 'ip-whitelist')
-    namespace = os.environ.get('WHITELIST_TRAEFIK_NAMESPACE', 'traefik-system')
+    name = os.environ.get('ALLOWLIST_MIDDLEWARE_NAME', 'ip-allowlist')
+    namespace = os.environ.get('ALLOWLIST_TRAEFIK_NAMESPACE', 'traefik-system')
 
     patch_resource = api.patch_namespaced_custom_object(
-        group="traefik.containo.us",
+        group="traefik.io",
         version="v1alpha1",
         name=name,
         namespace=namespace,


### PR DESCRIPTION
Updates the middleware to `ipAllowList` and uses the `traefik.io/v1alpha1` api version.

Note: This does rename the docker image. This could be beneficial to maintain a clean separation from the previous implementation.

Resolves #1 